### PR TITLE
Correction to debug statement in README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -196,7 +196,7 @@ You can run this script directly to see output logs
 * Run this command: 
 
 ```
-/usr/bin/php -d open_basedir=/usr/syno/bin/ddns -f /usr/syno/bin/ddns/cloudflare.php "" "domain1.com|vpn.domain2.com" "your-CloudFlare-token" "" ""
+/usr/bin/php -d open_basedir=/usr/syno/bin/ddns -f /usr/syno/bin/ddns/cloudflare.php "<username>" "<password>" "<hostname>" "<ipv4>"
 ```
 
 * Check output logs


### PR DESCRIPTION
Debug statement has 5 parameters for the script, where it should have 4, returning `badparams`. Also clarified the meaning of the parameters.