### PR TITLE
Handle IDN Cloudflare zones without PHP intl by resolving zone ID from hostname

### DIFF
--- a/cloudflare.php
+++ b/cloudflare.php
@@ -131,6 +131,14 @@ class CloudflareAPI
         return $this->call("GET", "client/v4/zones?per_page=" . self::ZONES_PER_PAGE . "&status=active");
     }
 
+    public function getZoneByName($zoneName)
+{
+    return $this->call(
+        "GET",
+        "client/v4/zones?name=" . rawurlencode($zoneName) . "&status=active"
+    );
+}
+
     /**
      * @link https://developers.cloudflare.com/api/operations/dns-records-for-a-zone-list-dns-records
      * @throws Exception
@@ -341,42 +349,64 @@ class SynologyCloudflareDDNSAgent
     private function matchHostnameWithZone($hostnameList = [])
     {
         try {
-            $zoneList = $this->cloudflareAPI->getZones();
-            $zoneList = $zoneList['result'];
-            foreach ($zoneList as $zone) {
-                $zoneId = $zone['id'];
-                $zoneName = $zone['name'];
-                foreach ($hostnameList as $hostname) {
-                    // Check if the hostname ends with the zone name
-                    if ($hostname === $zoneName || substr($hostname, -strlen('.' . $zoneName)) === '.' . $zoneName) {
-                        // Add an IPv4 DNS record for each hostname that matches a zone
-                        $this->dnsRecordList[] = new DnsRecordEntity(
-                            '',
-                            'A',
-                            $hostname,
-                            $this->ipv4,
-                            $zoneId,
-                            '',
-                            ''
-                        );
-                        if (isset($this->ipv6)) {
-                            // Add an IPv6 DNS record if an IPv6 address is available
-                            $this->dnsRecordList[] = new DnsRecordEntity(
-                                '',
-                                'AAAA',
-                                $hostname,
-                                $this->ipv6,
-                                $zoneId,
-                                '',
-                                ''
-                            );
-                        }
-                    }
+            foreach ($hostnameList as $hostname) {
+                $zoneId = $this->findZoneIdByHostname($hostname);
+
+                if (!$zoneId) {
+                    continue;
                 }
+
+                $this->dnsRecordList[] = new DnsRecordEntity(
+                    '',
+                    'A',
+                    $hostname,
+                    $this->ipv4,
+                    $zoneId,
+                    '',
+                    ''
+                );
+
+                if (isset($this->ipv6)) {
+                    $this->dnsRecordList[] = new DnsRecordEntity(
+                        '',
+                        'AAAA',
+                        $hostname,
+                        $this->ipv6,
+                        $zoneId,
+                        '',
+                        ''
+                    );
+                }
+            }
+
+            if (empty($this->dnsRecordList)) {
+                $this->exitWithSynologyMsg(SynologyOutput::NO_HOSTNAME);
             }
         } catch (Exception $e) {
             $this->exitWithSynologyMsg(SynologyOutput::NO_HOSTNAME);
         }
+    }
+
+    /**
+     * Summary of findZoneIdByHostname
+     * @param mixed $hostname
+     */
+    private function findZoneIdByHostname($hostname)
+    {
+        $hostname = strtolower(rtrim(trim($hostname), '.'));
+        $labels = explode('.', $hostname);
+        $count = count($labels);
+
+        for ($i = 0; $i <= $count - 2; $i++) {
+            $candidateZone = implode('.', array_slice($labels, $i));
+            $zone = $this->cloudflareAPI->getZoneByName($candidateZone);
+
+            if (!empty($zone['result']) && !empty($zone['result'][0]['id'])) {
+                return $zone['result'][0]['id'];
+            }
+        }
+
+        return null;
     }
 
     /**

--- a/tests/SynologyCloudflareDDNSAgentTest.php
+++ b/tests/SynologyCloudflareDDNSAgentTest.php
@@ -15,11 +15,12 @@ class TestableSynologyCloudflareDDNSAgent extends SynologyCloudflareDDNSAgent
         $this->exitMsg = $msg;
         throw new ExitException("Exit called with message: $msg");
     }
-    
+
     public function callPrivateMethod($methodName, $args = [])
     {
         $reflection = new ReflectionClass($this);
         $method = $reflection->getMethod($methodName);
+        $method->setAccessible(true);
         return $method->invokeArgs($this, $args);
     }
 }
@@ -30,13 +31,27 @@ class SynologyCloudflareDDNSAgentTest extends TestCase
     {
         $mockApi = $this->createMock(CloudflareAPI::class);
         $mockIpify = $this->createMock(Ipify::class);
-        
+
         $mockApi->method('verifyToken')->willReturn(['success' => true]);
-        
-        $mockApi->method('getZones')->willReturn(['result' => []]);
+
+        $mockApi->method('getZoneByName')
+            ->willReturnCallback(function ($zoneName) {
+                if ($zoneName === 'example.com') {
+                    return [
+                        'result' => [
+                            [
+                                'id' => 'test-zone-id',
+                                'name' => 'example.com',
+                            ]
+                        ]
+                    ];
+                }
+
+                return ['result' => []];
+            });
 
         $agent = new TestableSynologyCloudflareDDNSAgent('apikey', 'example.com', '1.2.3.4', $mockApi, $mockIpify);
-        
+
         $this->assertTrue($agent->callPrivateMethod('isValidHostname', ['example.com']));
         $this->assertTrue($agent->callPrivateMethod('isValidHostname', ['sub.example.com']));
         $this->assertFalse($agent->callPrivateMethod('isValidHostname', ['-example.com']));
@@ -47,22 +62,38 @@ class SynologyCloudflareDDNSAgentTest extends TestCase
     {
         $mockApi = $this->createMock(CloudflareAPI::class);
         $mockIpify = $this->createMock(Ipify::class);
+
         $mockApi->method('verifyToken')->willReturn(['success' => true]);
-        $mockApi->method('getZones')->willReturn(['result' => []]);
+
+        $mockApi->method('getZoneByName')
+            ->willReturnCallback(function ($zoneName) {
+                if ($zoneName === 'example.com') {
+                    return [
+                        'result' => [
+                            [
+                                'id' => 'test-zone-id',
+                                'name' => 'example.com',
+                            ]
+                        ]
+                    ];
+                }
+
+                return ['result' => []];
+            });
 
         $agent = new TestableSynologyCloudflareDDNSAgent('apikey', 'example.com', '1.2.3.4', $mockApi, $mockIpify);
 
         $input = "example.com|sub.example.com|invalid-";
         $expected = ['example.com', 'sub.example.com'];
-        
+
         $this->assertEquals($expected, $agent->callPrivateMethod('extractHostnames', [$input]));
     }
-    
+
     public function testConstructorAuthFailure()
     {
         $mockApi = $this->createMock(CloudflareAPI::class);
         $mockIpify = $this->createMock(Ipify::class);
-        
+
         $mockApi->method('verifyToken')->willReturn(['success' => false]);
 
         $this->expectException(ExitException::class);


### PR DESCRIPTION
**Summary**

This changes the Cloudflare zone matching logic to support IDN domains on Synology systems that do not have the PHP intl extension enabled.

Previously, the code fetched all zones and compared each configured hostname against zone['name']. This fails for IDN domains because Cloudflare may return the Unicode form of the zone name, while Synology configuration may contain the punycode form. For example:

- configured hostname / zone: xn--la-rka.tw
- Cloudflare zone name: lúa.tw

Without intl, PHP cannot reliably normalize and compare those values.

**What changed**

Instead of comparing hostnames to the zone name returned by Cloudflare, this patch:

- derives candidate zone suffixes from each configured hostname
- queries Cloudflare for a zone by name=...
- uses the returned zone_id directly

This avoids Unicode vs punycode comparison entirely and works without adding new PHP extensions or dependencies.

**Why**

This makes IDN zone resolution work correctly on Synology environments where:

- intl is not installed
- users do not want to install or enable extra PHP modules

It also makes the logic more reliable by using Cloudflare’s zone lookup directly rather than depending on display-name equality.

**Example**

For a hostname like:

`sub.xn--la-rka.tw`

the resolver tries suffixes such as:

```
sub.xn--la-rka.tw
xn--la-rka.tw
```

and uses the first matching Cloudflare zone result to obtain the correct zone_id.

**Result**

- fixes IDN domain handling without intl
- avoids Unicode/punycode string mismatch
- keeps the implementation lightweight and Synology-friendly